### PR TITLE
Option to equalise exp from a co-op vault

### DIFF
--- a/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
+++ b/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
@@ -7,6 +7,7 @@ public class VaultCoopOnlyConfig extends Config{
     @Expose
     public Boolean IS_COOP_ONLY;
     public Boolean VAULT_EXP_EQUAL;
+    public Boolean EXTRA_BOSS_CRATES;
     
     public String getName() {
         return "vault_coop_only";
@@ -14,11 +15,17 @@ public class VaultCoopOnlyConfig extends Config{
     public String getXPShare() {
         return "vault_exp_equal";
     }
+    public String getExtraCrate() {
+        return "vault_extra_boss_crates";
+    }
 
     public void reset(){
         this.IS_COOP_ONLY=false;
     }
     public void resetXPShare(){
+        this.VAULT_EXP_EQUAL=false;
+    }
+    public void resetExtraCrate(){
         this.VAULT_EXP_EQUAL=false;
     }
 }

--- a/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
+++ b/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
@@ -6,12 +6,19 @@ public class VaultCoopOnlyConfig extends Config{
     
     @Expose
     public Boolean IS_COOP_ONLY;
+    public Boolean VAULT_EXP_EQUAL;
     
     public String getName() {
         return "vault_coop_only";
     }
+    public String getXPShare() {
+        return "vault_exp_equal";
+    }
 
     public void reset(){
         this.IS_COOP_ONLY=false;
+    }
+    public void resetXPShare(){
+        this.VAULT_EXP_EQUAL=false;
     }
 }

--- a/src/main/java/iskallia/vault/event/EntityEvents.java
+++ b/src/main/java/iskallia/vault/event/EntityEvents.java
@@ -206,10 +206,16 @@ public class EntityEvents {
 				if(count != 0) {
 					stacks.add(new ItemStack(ModItems.ETERNAL_SOUL, world.rand.nextInt(count) + 1));
 				}
-
-				ItemStack crate = VaultCrateBlock.getCrateWithLoot(ModBlocks.VAULT_CRATE, stacks);
-
-				event.getEntity().entityDropItem(crate);
+				if(ModConfigs.VAULT_COOP_ONLY.EXTRA_BOSS_CRATES) {
+                    ItemStack crate = VaultCrateBlock.getCrateWithLoot(ModBlocks.VAULT_CRATE, stacks);
+                    event.getEntity().entityDropItem(crate);
+                }
+				else {
+				    if(event.getSource().getTrueSource()==player) {
+                        ItemStack crate = VaultCrateBlock.getCrateWithLoot(ModBlocks.VAULT_CRATE, stacks);
+                        event.getEntity().entityDropItem(crate);
+                    }
+                }
 
 				FireworkRocketEntity fireworks = new FireworkRocketEntity(world, event.getEntity().getPosX(),
 						event.getEntity().getPosY(), event.getEntity().getPosZ(), new ItemStack(Items.FIREWORK_ROCKET));

--- a/src/main/java/iskallia/vault/world/raid/VaultRaid.java
+++ b/src/main/java/iskallia/vault/world/raid/VaultRaid.java
@@ -203,6 +203,12 @@ public class VaultRaid implements INBTSerializable<CompoundNBT> {
         this.finished = true;
 
         this.runForAll(world.getServer(), player -> {
+            float range;
+            float tnl=0;
+            if(ModConfigs.VAULT_COOP_ONLY.VAULT_EXP_EQUAL) {
+                range = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MAX - ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN;
+                tnl = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN + world.rand.nextFloat() * range;
+            }
             if (!player.removed && player.world.getDimensionKey() == Vault.VAULT_KEY) {
                 this.teleportToStart(world, player);
             }
@@ -212,8 +218,10 @@ public class VaultRaid implements INBTSerializable<CompoundNBT> {
             List<UUID> list = this.spectators.stream().map(spectator -> spectator.uuid).collect(Collectors.toList());
 
             if (!player.removed && !list.contains(player.getUniqueID())) {
-                float range = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MAX - ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN;
-                float tnl = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN + world.rand.nextFloat() * range;
+                if(!ModConfigs.VAULT_COOP_ONLY.VAULT_EXP_EQUAL) {
+                    range = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MAX - ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN;
+                    tnl = ModConfigs.VAULT_GENERAL.VAULT_EXIT_TNL_MIN + world.rand.nextFloat() * range;
+                }
 
                 PlayerVaultStatsData statsData = PlayerVaultStatsData.get(world);
                 PlayerVaultStats stats = statsData.getVaultStats(player);


### PR DESCRIPTION
Vaults distribute a random amount of EXP. Under normal circumstances this is rolled for the _one_ player in the vault; 
As co-op has more than one player involved it could be considered "unfair" for each player getting different exp values.
This is a "fix" option for that.