### PR TITLE
A few fixes, and a new option.

### DIFF
--- a/src/main/java/iskallia/vault/Vault.java
+++ b/src/main/java/iskallia/vault/Vault.java
@@ -1,6 +1,7 @@
 package iskallia.vault;
 
 import iskallia.vault.init.ModCommands;
+import iskallia.vault.init.ModConfigs;
 import iskallia.vault.init.ModFeatures;
 import iskallia.vault.world.data.PlayerAbilitiesData;
 import iskallia.vault.world.data.PlayerResearchesData;
@@ -81,6 +82,7 @@ public class Vault {
         if(!teamExists)
         {
             raiders = event.getServer().getScoreboard().createTeam("hunters");
+            if(!ModConfigs.VAULT_COOP_ONLY.RAIDER_FRIENDLYFIRE)raiders.setAllowFriendlyFire(false);
         }
 
     }

--- a/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
+++ b/src/main/java/iskallia/vault/config/VaultCoopOnlyConfig.java
@@ -7,6 +7,7 @@ public class VaultCoopOnlyConfig extends Config{
     @Expose public Boolean IS_COOP_ONLY;
     @Expose public Boolean VAULT_EXP_EQUAL;
     @Expose public Boolean EXTRA_BOSS_CRATES;
+    @Expose public Boolean RAIDER_FRIENDLYFIRE;
     
     public String getName() {
         return "vault_coop_only";
@@ -22,6 +23,7 @@ public class VaultCoopOnlyConfig extends Config{
         this.IS_COOP_ONLY=false;
         this.VAULT_EXP_EQUAL=false;
         this.EXTRA_BOSS_CRATES=false;
+        this.RAIDER_FRIENDLYFIRE=false;
     }
     public void resetXPShare(){
         this.VAULT_EXP_EQUAL=false;

--- a/src/main/java/iskallia/vault/event/EntityEvents.java
+++ b/src/main/java/iskallia/vault/event/EntityEvents.java
@@ -308,7 +308,8 @@ public class EntityEvents {
 		if(raiders!=null&&raiders.getName().equals("hunters"))
         {
             serverBoard.removeTeam(raiders);
-            serverBoard.createTeam("hunters");
+            raiders = serverBoard.createTeam("hunters");
+            if(!ModConfigs.VAULT_COOP_ONLY.RAIDER_FRIENDLYFIRE)raiders.setAllowFriendlyFire(false);
         }
         VaultRaid raid = VaultRaidData.get(player.getServerWorld()).getActiveFor(player);
         List<ServerPlayerEntity> raiders = new ArrayList<>(player.getServerWorld().getPlayers());

--- a/src/main/java/iskallia/vault/world/raid/VaultRaid.java
+++ b/src/main/java/iskallia/vault/world/raid/VaultRaid.java
@@ -244,7 +244,8 @@ public class VaultRaid implements INBTSerializable<CompoundNBT> {
             if(raiders!=null&&raiders.getName().equals("hunters"))
             {
                 serverBoard.removeTeam(raiders);
-                serverBoard.createTeam("hunters");
+                raiders = serverBoard.createTeam("hunters");
+                if(!ModConfigs.VAULT_COOP_ONLY.RAIDER_FRIENDLYFIRE)raiders.setAllowFriendlyFire(false);
             }
         });
 


### PR DESCRIPTION
The crude co-op team tracker could be lost, leading to broken team tracking.

VAULT_EXP_EQUAL was not equally distributing exp when TRUE.

RAIDER_FRIENDLYFIRE <true/false> is now a value and does what it says to the crude co-op team created by the mod. This is important as the team is deleted upon exiting of a vault to prevent accidental re-joining of future faults due to players forgetting to leave.