### PR TITLE
"internal" cmd cfg. & MAJOR bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ mixin {
 def mc_version = "1.16.3"
 version = "${mc_version}-1"
 
-version = '1.0.5-streamer'
+version = '1.0.6-streamer'
 group = 'iskallia.vault' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 
 archivesBaseName = 'the_vault'

--- a/src/main/java/iskallia/vault/command/InternalCommand.java
+++ b/src/main/java/iskallia/vault/command/InternalCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import iskallia.vault.init.ModConfigs;
 import iskallia.vault.item.CrystalData;
 import iskallia.vault.item.ItemGiftBomb;
 import iskallia.vault.item.ItemGiftBomb.Variant;
@@ -30,31 +31,37 @@ public class InternalCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) { 
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
         builder.then(
-            Commands.literal("received_sub_gift")
-                    .then(Commands.argument("actor", StringArgumentType.word())
-                    .then(Commands.argument("amount", IntegerArgumentType.integer())
-                    .then(Commands.argument("tier", IntegerArgumentType.integer(0,3))
-                    .executes(context -> receivedSubGift(context)))))
+                Commands.literal("received_sub")
+                        .then(Commands.argument("actor", StringArgumentType.word())
+                                .then(Commands.argument("tier", IntegerArgumentType.integer(0,3))
+                                        .executes(InternalCommand::receivedSub)))
         );
         builder.then(
-            Commands.literal("received_donation")
-                    .then(Commands.argument("actor", StringArgumentType.word())
-                    .then(Commands.argument("amount", IntegerArgumentType.integer())
-                    .executes(context -> receivedDonation(context))))
+                Commands.literal("received_sub_gift")
+                        .then(Commands.argument("actor", StringArgumentType.word())
+                                .then(Commands.argument("amount", IntegerArgumentType.integer())
+                                        .then(Commands.argument("tier", IntegerArgumentType.integer(0,3))
+                                                .executes(InternalCommand::receivedSubGift))))
         );
         builder.then(
-            Commands.literal("received_bit_donation")
-                    .then(Commands.argument("actor", StringArgumentType.word())
-                    .then(Commands.argument("amount", IntegerArgumentType.integer())
-                    .executes(context -> receivedBitDonation(context))))
+                Commands.literal("received_donation")
+                        .then(Commands.argument("actor", StringArgumentType.word())
+                                .then(Commands.argument("amount", IntegerArgumentType.integer())
+                                        .executes(InternalCommand::receivedDonation)))
+        );
+        builder.then(
+                Commands.literal("received_bit_donation")
+                        .then(Commands.argument("actor", StringArgumentType.word())
+                                .then(Commands.argument("amount", IntegerArgumentType.integer())
+                                        .executes(InternalCommand::receivedBitDonation)))
         );
 
         builder.then(
-            Commands.literal("raffle")
-                    .then(Commands.argument("actor", StringArgumentType.word())
-                    .executes(context -> raffle(context)))
+                Commands.literal("raffle")
+                        .then(Commands.argument("actor", StringArgumentType.word())
+                                .executes(InternalCommand::raffle))
         );
     }
 
@@ -63,27 +70,60 @@ public class InternalCommand extends Command {
         int amount = IntegerArgumentType.getInteger(context,"amount");
         int tier = IntegerArgumentType.getInteger(context,"tier");
         int variant = 0;
-        if(amount >=5){
-            if(amount < 10)
-                variant = 0;
-            if(amount >= 10 && amount < 20)
+        if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(0))
+        {
+            if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(1) && amount < ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(2))
                 variant = 1;
-            if(amount >= 20 && amount < 50)
+            else if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(2) && amount < ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(3))
                 variant = 2;
-            if(amount >= 50)
+            else if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUB_BRACKETS.get(3))
                 variant = 3;
             ItemStack item = ItemGiftBomb.forGift(Variant.values()[variant], actor, amount);
             EntityHelper.giveItem(context.getSource().asPlayer(), item);
         }
+        if(ModConfigs.VAULT_STREAMER_CONFIG.GIFT_SUBS_GIVE_BITS) GiveBitsCommand.dropBits(context.getSource().asPlayer(), amount*500);
         return 0;
     }
-    
+
+    private static int receivedSub(CommandContext<CommandSource> context) throws CommandSyntaxException {
+        String actor = StringArgumentType.getString(context, "actor");
+        int amount = 0;
+        int tier = IntegerArgumentType.getInteger(context,"tier");
+        int variant = 0;
+        boolean GiveTrader = ModConfigs.VAULT_STREAMER_CONFIG.SUBS_GIVE_TRADER;
+        boolean GiveBits = ModConfigs.VAULT_STREAMER_CONFIG.SUBS_GIVE_BITS;
+        boolean Rarity = ModConfigs.VAULT_STREAMER_CONFIG.SUB_BRACKET_AS_RARITY;
+        CoreType corerare = CoreType.COMMON;
+        if(tier<2&&GiveBits) amount = 500;
+        if(tier==2)
+        {
+            if(GiveBits) amount = 1000;
+            if(Rarity) corerare = CoreType.RARE;
+        }
+        if(tier==3)
+        {
+            if(GiveBits) amount = 2500;
+            if(Rarity) corerare = CoreType.OMEGA;
+        }
+        boolean isMegaHead = amount >= 2500;
+        if(GiveTrader) {
+            ItemStack item = ItemTraderCore.generate(actor, amount, isMegaHead, corerare);
+            EntityHelper.giveItem(context.getSource().asPlayer(), item);
+        }
+        GiveBitsCommand.dropBits(context.getSource().asPlayer(), amount);
+        return 0;
+    }
+
     private static int receivedDonation(CommandContext<CommandSource> context) throws CommandSyntaxException {
         String actor = StringArgumentType.getString(context, "actor");
         int amount = IntegerArgumentType.getInteger(context,"amount");
         boolean isMegaHead = amount >= 100;
-        if(amount >= 25){
-            ItemStack item = ItemTraderCore.generate(actor,amount,isMegaHead,CoreType.COMMON);
+        CoreType corerare = CoreType.COMMON;
+        if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(0)){
+            if(ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(1)!=-1&&(amount>=ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(1)&&amount<=ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(2))) corerare = CoreType.RARE;
+            if(ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(2)!=-1&&(amount>=ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(1)&&amount<=ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(3))) corerare = CoreType.EPIC;
+            if(ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(3)!=-1&&amount>=ModConfigs.VAULT_STREAMER_CONFIG.DONOR_TRADER_BRACKETS.get(1)) corerare = CoreType.OMEGA;
+            ItemStack item = ItemTraderCore.generate(actor,amount,isMegaHead,corerare);
             EntityHelper.giveItem(context.getSource().asPlayer(), item);
         }
         return 0;
@@ -92,15 +132,20 @@ public class InternalCommand extends Command {
     private static int receivedBitDonation(CommandContext<CommandSource> context) throws CommandSyntaxException {
         String actor = StringArgumentType.getString(context, "actor");
         int amount = IntegerArgumentType.getInteger(context,"amount");
-        boolean isMegaHead = amount >= 10000;
-        if(amount >= 2500){
-            ItemStack item = ItemTraderCore.generate(actor, amount, isMegaHead, CoreType.COMMON);
+        boolean GiveTrader = ModConfigs.VAULT_STREAMER_CONFIG.BITS_GIVE_TRADER;
+        boolean isMegaHead = amount >= ModConfigs.VAULT_STREAMER_CONFIG.BIT_MEGA_HEAD;
+        CoreType corerare = CoreType.COMMON;
+        if(ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(1)!=-1&&(amount >= ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(1) && amount < ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(2))) corerare = CoreType.RARE;
+        if(ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(2)!=-1&&(amount >= ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(2) && amount < ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(3))) corerare = CoreType.EPIC;
+        if(ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(3)!=-1&&(amount >= ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(3))) corerare = CoreType.OMEGA;
+        if(amount >= ModConfigs.VAULT_STREAMER_CONFIG.BIT_BRACKETS.get(0) && GiveTrader){
+            ItemStack item = ItemTraderCore.generate(actor, amount, isMegaHead, corerare);
             EntityHelper.giveItem(context.getSource().asPlayer(), item);
         }
         GiveBitsCommand.dropBits(context.getSource().asPlayer(), amount);
         return 0;
     }
-    
+
     private static int raffle(CommandContext<CommandSource> context) throws CommandSyntaxException {
         String actor = StringArgumentType.getString(context, "actor");
         ItemStack item = ItemVaultCrystal.getCrystalWithBoss(actor);

--- a/src/main/java/iskallia/vault/config/VaultStreamerConfig.java
+++ b/src/main/java/iskallia/vault/config/VaultStreamerConfig.java
@@ -1,0 +1,37 @@
+package iskallia.vault.config;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class VaultStreamerConfig extends Config{
+    
+    @Expose public ArrayList<Integer> GIFT_SUB_BRACKETS = new ArrayList<>();
+    @Expose public Boolean GIFT_SUBS_GIVE_BITS = false;
+    @Expose public Integer DONOR_MEGA_HEAD = 100;
+    @Expose public ArrayList<Integer> DONOR_TRADER_BRACKETS = new ArrayList<>();
+    @Expose public Boolean BITS_GIVE_TRADER = false;
+    @Expose public ArrayList<Integer> BIT_BRACKETS = new ArrayList<>();
+    @Expose public Integer BIT_MEGA_HEAD = 10000;
+    @Expose public Boolean SUBS_GIVE_TRADER = false;
+    @Expose public Boolean SUB_BRACKET_AS_RARITY = false;
+    @Expose public Boolean SUBS_GIVE_BITS = false;
+
+    public String getName() {
+        return "vault_streamer_config";
+    }
+
+    public void reset(){
+        this.GIFT_SUB_BRACKETS = new ArrayList<>(Arrays.asList(5, 10, 20, 50));
+        this.GIFT_SUBS_GIVE_BITS = false;
+        this.DONOR_MEGA_HEAD = 100;
+        this.DONOR_TRADER_BRACKETS = new ArrayList<>(Arrays.asList(25, -1, -1, -1));
+        this.BITS_GIVE_TRADER = false;
+        this.BIT_BRACKETS = new ArrayList<>(Arrays.asList(2500, -1, -1, -1));
+        this.BIT_MEGA_HEAD = 10000;
+        this.SUBS_GIVE_TRADER = false;
+        this.SUB_BRACKET_AS_RARITY = false;
+        this.SUBS_GIVE_BITS = false;
+    }
+}

--- a/src/main/java/iskallia/vault/init/ModConfigs.java
+++ b/src/main/java/iskallia/vault/init/ModConfigs.java
@@ -57,6 +57,7 @@ public class ModConfigs {
     public static PlayerExpConfig PLAYER_EXP;
     public static FinalVaultGeneralConfig FINAL_VAULT_GENERAL;
     public static VaultCoopOnlyConfig VAULT_COOP_ONLY;
+    public static VaultStreamerConfig VAULT_STREAMER_CONFIG;
 
     public static void register() {
         ABILITIES = (AbilitiesConfig) new AbilitiesConfig().readConfig();
@@ -108,6 +109,7 @@ public class ModConfigs {
         PLAYER_EXP = (PlayerExpConfig) new PlayerExpConfig().readConfig();
         FINAL_VAULT_GENERAL = (FinalVaultGeneralConfig) new FinalVaultGeneralConfig().readConfig();
         VAULT_COOP_ONLY = (VaultCoopOnlyConfig) new VaultCoopOnlyConfig().readConfig();
+        VAULT_STREAMER_CONFIG = (VaultStreamerConfig) new VaultStreamerConfig().readConfig();
         Vault.LOGGER.info("Vault Configs are loaded successfully!");
     }
 

--- a/src/main/java/iskallia/vault/world/data/VaultRaidData.java
+++ b/src/main/java/iskallia/vault/world/data/VaultRaidData.java
@@ -128,7 +128,6 @@ public class VaultRaidData extends WorldSavedData {
     }
 
     public void tick(ServerWorld world) {
-        this.activeRaids.values().forEach(vaultRaid -> vaultRaid.tick(world));
 
         boolean removed = false;
 
@@ -136,17 +135,20 @@ public class VaultRaidData extends WorldSavedData {
         List<UUID> tickedOwners = new ArrayList<>();
 
         for (VaultRaid raid : this.activeRaids.values()) {
+            if(!tickedOwners.contains(raid.owner))
+            {
+                raid.ticksLeft--;
+                raid.syncTicksLeft(world.getServer());
+                tickedOwners.add(raid.owner);
+            }
             if(raid.isComplete()) {
                 raid.syncTicksLeft(world.getServer());
                 tasks.add(() -> raid.playerIds.forEach(uuid -> this.remove(world, uuid)));
                 removed = true;
             }
-            if(!tickedOwners.contains(raid.owner))
-            {
-                raid.ticksLeft--;
-                tickedOwners.add(raid.owner);
-            }
         }
+
+        this.activeRaids.values().forEach(vaultRaid -> vaultRaid.tick(world));
 
         tasks.forEach(Runnable::run);
 


### PR DESCRIPTION
Previous iteraction of co-op raids would not "time out" or finish on a boss run. This was due to a mistake with a re-organisation of Server's raid.tick() , causing all player's raid.tick() to not see the 0th tick of the timer.

Internal command now also has config customisation through the roof.